### PR TITLE
Hotfix url

### DIFF
--- a/scripts/FAA-TFR-scraper.R
+++ b/scripts/FAA-TFR-scraper.R
@@ -1,13 +1,15 @@
 # Load Dependencies
 ## See XML package documentation https://cran.r-project.org/web/packages/XML/XML.pdf
 library(XML)
+library(RCurl)
 library(httr)
 
 # Set working directory
 setwd("")
 
-url <- "http://tfr.faa.gov/tfr2/list.jsp"
-tables <- readHTMLTable(url)
+url <- "https://tfr.faa.gov/tfr2/list.html"
+xdata <- getURL(url)
+tables <- readHTMLTable(xdata)
 tfrTable <- tables[[5]]
 
 # Clean up raw table
@@ -34,7 +36,7 @@ tfrData$timestamp <- timestamp
 # Next steps are to loop over NOTAM ids to fetch detailed xml and add detailed TFR data
 tfrNotam <- c(as.character(tfrData$notam))
 
-xml_prefix <- "http://tfr.faa.gov/save_pages/detail_"
+xml_prefix <- "https://tfr.faa.gov/save_pages/detail_"
 xml_suffix <- ".xml"
 
 # Generate new columns in data frame
@@ -57,7 +59,8 @@ for(notam in as.factor(tfrNotam)) {
     xmlUrl <- paste(xml_prefix, notam, xml_suffix, sep="")
 
     if(GET(xmlUrl)$status == 200) {
-        notamXML <- xmlParse(xmlUrl)
+        xmlData <- getURLContent(xmlUrl)
+        notamXML <- xmlParse(xmlData)
 
         ## Global identifier
         guid <- xpathSApply(notamXML, "/XNOTAM-Update/Group/Add/Not/NotUid/codeGUID", xmlValue)

--- a/scripts/FAA-TFR-scraper.R
+++ b/scripts/FAA-TFR-scraper.R
@@ -55,7 +55,7 @@ i <- 1
 
 for(notam in as.factor(tfrNotam)) {
     xmlUrl <- paste(xml_prefix, notam, xml_suffix, sep="")
-    
+
     if(GET(xmlUrl)$status == 200) {
         notamXML <- xmlParse(xmlUrl)
 
@@ -87,8 +87,8 @@ for(notam in as.factor(tfrNotam)) {
         if (length(notamFull) > 0 ) { tfrData$notam_fulltext[i] <- notamFull }
         if (length(guid) > 0 ) { tfrData$guid[i] <- guid }
     }
-    
-    i <- i + 1 
+
+    i <- i + 1
 }
 
 # Clean data obtained from detail XML page to avoid formatting issues
@@ -139,7 +139,7 @@ for (i in seq(1, nrow(tfrData), by=1)) {
         l <- length(newTFRs)
         newTFRs[l+1] <- newGuid
     }
-    
+
     i <- i + 1
 }
 

--- a/scripts/shapefile-download.sh
+++ b/scripts/shapefile-download.sh
@@ -7,7 +7,7 @@ do
     temp_notam="${notam%\"}"
     temp_guid="${temp_guid#\"}"
     temp_notam="${temp_notam#\"}"
-    wget http://tfr.faa.gov/save_pages/$temp_notam.shp.zip -P /tmp/
+    wget https://tfr.faa.gov/save_pages/$temp_notam.shp.zip -P /tmp/
     
     if [ -f "/tmp/$temp_notam.shp.zip" ]; then
         unzip /tmp/$temp_notam.shp.zip -d /home/ec2-user/shapefiles/$temp_guid
@@ -27,7 +27,7 @@ if [ -f "/home/ec2-user/newTFRids-archive.csv" ]; then
         temp_notam="${temp_notam#\"}"
         temp_date="${timestamp%\"}"
         temp_date="${temp_date#\"}"
-        wget http://tfr.faa.gov/save_pages/$temp_notam.shp.zip -P /tmp/
+        wget https://tfr.faa.gov/save_pages/$temp_notam.shp.zip -P /tmp/
     
         if [ -f "/tmp/$temp_notam.shp.zip" ]; then
             unzip /tmp/$temp_notam.shp.zip -d /home/ec2-user/shapefiles/$temp_guid


### PR DESCRIPTION
FAA TFR webpage switched to https over the weekend, causing the scraper to break. URLs have been corrected to reflect https, and RCurl library has been added to r script to correct issues created by https with XML parsing.